### PR TITLE
Ignore return code of db-migrate up

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node_modules/.bin/db-migrate up && node app.js
+web: node_modules/.bin/db-migrate up; node app.js


### PR DESCRIPTION
Due to an [issue](https://github.com/mysqljs/mysql/issues/1334) in the interaction of the mysql client and ClearDB, `db-migrate up` can exit due to an exception even if the migration succeeds. Ignoring the return code allows the app to start successfully. Logs from an unsuccessful push where the migrations all ran successfully but the issue stated above caused an exception:

```
2016-09-14T10:13:40.87-0400 [APP/0]      OUT [INFO] Processed migration 20141201112350-add-result
2016-09-14T10:14:10.89-0400 [APP/0]      ERR [ERROR] Error: Quit inactivity timeout
2016-09-14T10:14:10.89-0400 [APP/0]      ERR     at Quit.<anonymous> (/home/vcap/app/node_modules/mysql/lib/protocol/Protocol.js:160:17)
2016-09-14T10:14:10.89-0400 [APP/0]      ERR     at emitNone (events.js:67:13)
2016-09-14T10:14:10.89-0400 [APP/0]      ERR     at Quit.emit (events.js:166:7)
2016-09-14T10:14:10.89-0400 [APP/0]      ERR     at Quit._onTimeout (/home/vcap/app/node_modules/mysql/lib/protocol/sequences/Sequence.js:126:8)
2016-09-14T10:14:10.89-0400 [APP/0]      ERR     at Timer.listOnTimeout (timers.js:92:15)
2016-09-14T10:14:10.89-0400 [APP/0]      ERR     --------------------
2016-09-14T10:14:10.89-0400 [APP/0]      ERR     at Protocol._enqueue (/home/vcap/app/node_modules/mysql/lib/protocol/Protocol.js:141:48)
2016-09-14T10:14:10.89-0400 [APP/0]      ERR     at Protocol.quit (/home/vcap/app/node_modules/mysql/lib/protocol/Protocol.js:88:23)
2016-09-14T10:14:10.89-0400 [APP/0]      ERR     at Connection.end (/home/vcap/app/node_modules/mysql/lib/Connection.js:255:18)
2016-09-14T10:14:10.89-0400 [APP/0]      ERR     at Class.Base.extend.close (/home/vcap/app/node_modules/db-migrate/lib/driver/mysql.js:291:21)
2016-09-14T10:14:10.89-0400 [APP/0]      ERR     at Query.onComplete (/home/vcap/app/node_modules/db-migrate/bin/db-migrate:196:19)
2016-09-14T10:14:10.89-0400 [APP/0]      ERR     at /home/vcap/app/node_modules/db-migrate/node_modules/async/lib/async.js:116:25
2016-09-14T10:14:10.89-0400 [APP/0]      ERR     at Class.module.exports.Class.extend.endMigration (/home/vcap/app/node_modules/db-migrate/lib/driver/base.js:231:30)
2016-09-14T10:14:10.89-0400 [APP/0]      ERR     at /home/vcap/app/node_modules/db-migrate/lib/migrator.js:108:77
2016-09-14T10:14:10.89-0400 [APP/0]      ERR     at Query.onComplete [as _callback] (/home/vcap/app/node_modules/db-migrate/lib/migrator.js:55:7)
2016-09-14T10:14:10.89-0400 [APP/0]      ERR     at Query.Sequence.end (/home/vcap/app/node_modules/mysql/lib/protocol/sequences/Sequence.js:85:24)
```

Since `db-migrate up` didn't exit with success, `node app.js` didn't run and hence the app didn't start