### PR TITLE
Don't assume path prefix for installed node binaries

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node_modules/.bin/db-migrate up; node app.js
+web: db-migrate up; node app.js


### PR DESCRIPTION
This will cause issues on newer versions of the buildpack as we're moving towards keeping dependencies in a separate directory from the app code, so `node_modules/.bin` (relative from the app dir, in this case) may not be present.

The buildpack should put the binaries directly on the path wherever they are, so the command should just be invoked without any path prefix.

Signed-off-by: Sam Coward <scoward@pivotal.io>